### PR TITLE
Don't cd to the source directory by default

### DIFF
--- a/build/sync.js
+++ b/build/sync.js
@@ -131,7 +131,6 @@ module.exports = {
         }
       }
     });
-    process.chdir(options.source);
     console.info("Connecting with: " + params.uuid);
     performSync = function() {
       return Promise["try"](function() {

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -120,10 +120,6 @@ module.exports =
 						type: 'The delay option should be a number'
 						dependencies: 'The delay option should only be used with watch'
 
-		# Change directory to allow child processes inherit
-		# the correct working directory automatically
-		process.chdir(options.source)
-
 		console.info("Connecting with: #{params.uuid}")
 
 		performSync = ->


### PR DESCRIPTION
Currently we `cd` to the source directory and also pass it to the rsync
command, which ends up duplicating the source directory in the path.
