### PR TITLE
Support persisting options in a configuration file

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -1,0 +1,85 @@
+
+/*
+The MIT License
+
+Copyright (c) 2015 Resin.io, Inc. https://resin.io.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+var fs, jsYaml, path, _;
+
+fs = require('fs');
+
+_ = require('lodash');
+
+path = require('path');
+
+jsYaml = require('js-yaml');
+
+
+/**
+ * @summary Get config path
+ * @function
+ * @private
+ *
+ * @returns {String} config path
+ *
+ * @example
+ * configPath = config.getPath()
+ */
+
+exports.getPath = function() {
+  return path.join(process.cwd(), 'resin-sync.yml');
+};
+
+
+/**
+ * @summary Load configuration file
+ * @function
+ * @protected
+ *
+ * @description
+ * If no configuration file is found, return an empty object.
+ *
+ * @returns {Object} configuration
+ *
+ * @example
+ * options = config.load()
+ */
+
+exports.load = function() {
+  var config, configPath, error, result;
+  configPath = exports.getPath();
+  try {
+    config = fs.readFileSync(configPath, {
+      encoding: 'utf8'
+    });
+    result = jsYaml.safeLoad(config);
+  } catch (_error) {
+    error = _error;
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+  if (!_.isPlainObject(result)) {
+    throw new Error("Invalid configuration file: " + configPath);
+  }
+  return result;
+};

--- a/build/sync.js
+++ b/build/sync.js
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var Promise, resin, rsync, shell, ssh, tree, utils, _;
+var Promise, config, resin, rsync, shell, ssh, tree, utils, _;
 
 Promise = require('bluebird');
 
@@ -40,10 +40,12 @@ tree = require('./tree');
 
 ssh = require('./ssh');
 
+config = require('./config');
+
 module.exports = {
   signature: 'sync <uuid>',
   description: 'sync your changes with a device',
-  help: 'Use this command to sync your local changes to a certain device on the fly.\n\nExamples:\n\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9 --ignore foo,bar\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9 --watch --delay 4000',
+  help: 'Use this command to sync your local changes to a certain device on the fly.\n\nYou can save all the options mentioned below in a `resin-sync.yml` file, by using the same option names as keys. For example:\n\n	$ cat $PWD/resin-sync.yml\n	source: src/\n	before: \'echo Hello\'\n	exec: \'python main.py\'\n	ignore:\n		- .git\n		- node_modules/\n	progress: true\n	watch: true\n	delay: 2000\n\nNotice that explicitly passed command options override the ones set in the configuration file.\n\nExamples:\n\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9 --ignore foo,bar\n	$ resin sync 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9 --watch --delay 4000',
   permission: 'user',
   options: [
     {
@@ -88,6 +90,7 @@ module.exports = {
     if (options.ignore != null) {
       options.ignore = _.words(options.ignore);
     }
+    options = _.merge(config.load(), options);
     _.defaults(options, {
       source: process.cwd()
     });

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,70 @@
+###
+The MIT License
+
+Copyright (c) 2015 Resin.io, Inc. https://resin.io.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+###
+
+fs = require('fs')
+_ = require('lodash')
+path = require('path')
+jsYaml = require('js-yaml')
+
+###*
+# @summary Get config path
+# @function
+# @private
+#
+# @returns {String} config path
+#
+# @example
+# configPath = config.getPath()
+###
+exports.getPath = ->
+	return path.join(process.cwd(), 'resin-sync.yml')
+
+###*
+# @summary Load configuration file
+# @function
+# @protected
+#
+# @description
+# If no configuration file is found, return an empty object.
+#
+# @returns {Object} configuration
+#
+# @example
+# options = config.load()
+###
+exports.load = ->
+	configPath = exports.getPath()
+
+	try
+		config = fs.readFileSync(configPath, encoding: 'utf8')
+		result = jsYaml.safeLoad(config)
+	catch error
+		if error.code is 'ENOENT'
+			return {}
+		throw error
+
+	if not _.isPlainObject(result)
+		throw new Error("Invalid configuration file: #{configPath}")
+
+	return result

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -30,12 +30,28 @@ utils = require('./utils')
 shell = require('./shell')
 tree = require('./tree')
 ssh = require('./ssh')
+config = require('./config')
 
 module.exports =
 	signature: 'sync <uuid>'
 	description: 'sync your changes with a device'
 	help: '''
 		Use this command to sync your local changes to a certain device on the fly.
+
+		You can save all the options mentioned below in a `resin-sync.yml` file, by using the same option names as keys. For example:
+
+			$ cat $PWD/resin-sync.yml
+			source: src/
+			before: 'echo Hello'
+			exec: 'python main.py'
+			ignore:
+				- .git
+				- node_modules/
+			progress: true
+			watch: true
+			delay: 2000
+
+		Notice that explicitly passed command options override the ones set in the configuration file.
 
 		Examples:
 
@@ -85,6 +101,8 @@ module.exports =
 		# TODO: Add comma separated options to Capitano
 		if options.ignore?
 			options.ignore = _.words(options.ignore)
+
+		options = _.merge(config.load(), options)
 
 		_.defaults options,
 			source: process.cwd()

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "gulp-mocha": "~2.0.0",
     "gulp-util": "~3.0.1",
     "mocha": "~2.0.1",
-    "mochainon": "^1.0.0"
+    "mochainon": "^1.0.0",
+    "mock-fs": "^3.3.0"
   },
   "dependencies": {
     "bluebird": "^2.10.1",
+    "js-yaml": "^3.4.2",
     "lodash": "^3.10.1",
     "resin-sdk": "^2.8.0",
     "revalidator": "^0.3.1",

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -1,0 +1,59 @@
+m = require('mochainon')
+path = require('path')
+mockFs = require('mock-fs')
+config = require('../lib/config')
+
+describe 'Config:', ->
+
+	describe '.getPath()', ->
+
+		it 'should be an absolute path', ->
+			configPath = config.getPath()
+			isAbsolute = configPath is path.resolve(configPath)
+			m.chai.expect(isAbsolute).to.be.true
+
+		it 'should point to a yaml file', ->
+			configPath = config.getPath()
+			m.chai.expect(path.extname(configPath)).to.equal('.yml')
+
+	describe '.load()', ->
+
+		describe 'given the file contains valid yaml', ->
+
+			it 'should return the parsed contents', ->
+				filesystem = {}
+				filesystem[config.getPath()] = '''
+					source: 'src/'
+					before: 'echo Hello'
+				'''
+				mockFs(filesystem)
+
+				options = config.load()
+				m.chai.expect(options).to.deep.equal
+					source: 'src/'
+					before: 'echo Hello'
+
+				mockFs.restore()
+
+		describe 'given the file contains invalid yaml', ->
+
+			it 'should return the parsed contents', ->
+				filesystem = {}
+				filesystem[config.getPath()] = '''
+					1234
+				'''
+				mockFs(filesystem)
+
+				m.chai.expect(config.load).to.throw('Invalid configuration file')
+
+				mockFs.restore()
+
+		describe 'given the file does not exist', ->
+
+			it 'should return an empty object', ->
+				mockFs({})
+
+				options = config.load()
+				m.chai.expect(options).to.deep.equal({})
+
+				mockFs.restore()


### PR DESCRIPTION
The configuration file name is `resin-sync.yml`.

Explicitly passed command options override the ones set in the
configuration file.
