### PR TITLE
Split ignore option by a comma

### DIFF
--- a/build/sync.js
+++ b/build/sync.js
@@ -88,7 +88,7 @@ module.exports = {
   action: function(params, options, done) {
     var performSync;
     if (options.ignore != null) {
-      options.ignore = _.words(options.ignore);
+      options.ignore = options.ignore.split(',');
     }
     options = _.merge(config.load(), options);
     _.defaults(options, {

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -100,7 +100,7 @@ module.exports =
 
 		# TODO: Add comma separated options to Capitano
 		if options.ignore?
-			options.ignore = _.words(options.ignore)
+			options.ignore = options.ignore.split(',')
 
 		options = _.merge(config.load(), options)
 


### PR DESCRIPTION
Using `_.words` makes the value of the `ignore` option to also be
splitted by periods, so something like `test.avi` results in
`[ 'test', 'avi']`.
