### PR TITLE
Enable device URL as default

### DIFF
--- a/build/sync.js
+++ b/build/sync.js
@@ -168,6 +168,11 @@ module.exports = {
         throw new Error('Device is not online');
       }
     }).then(function() {
+      return resin.models.device.hasDeviceUrl(params.uuid);
+    }).then(function(hasDeviceUrl) {
+      if (!hasDeviceUrl) {
+        throw new Error('Device URL not enabled');
+      }
       return resin.models.device.get(params.uuid).get('uuid').then(performSync);
     }).then(function() {
       var watch;

--- a/build/sync.js
+++ b/build/sync.js
@@ -168,16 +168,17 @@ module.exports = {
         throw new Error('Device is not online');
       }
     }).then(function() {
-      return resin.models.device.get(params.uuid).get('uuid');
-    }).then(function(fullUUID) {
-      return resin.models.device.enableDeviceUrl(fullUUID);
-    }).then(function() {
       return resin.models.device.hasDeviceUrl(params.uuid);
     }).then(function(hasDeviceUrl) {
-      if (!hasDeviceUrl) {
-        throw new Error('DeviceURL couldn\'t be enabled');
+      if (hasDeviceUrl) {
+        return resin.models.device.get(params.uuid).get('uuid').then(performSync);
+      } else {
+        return resin.models.device.get(params.uuid).get('uuid').then(function(fullUUID) {
+          return resin.models.device.enableDeviceUrl(fullUUID).then(function() {
+            return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync);
+          });
+        });
       }
-      return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync);
     }).then(function() {
       var watch;
       if (!options.watch) {

--- a/build/sync.js
+++ b/build/sync.js
@@ -168,12 +168,16 @@ module.exports = {
         throw new Error('Device is not online');
       }
     }).then(function() {
+      return resin.models.device.get(params.uuid).get('uuid');
+    }).then(function(fullUUID) {
+      return resin.models.device.enableDeviceUrl(fullUUID);
+    }).then(function() {
       return resin.models.device.hasDeviceUrl(params.uuid);
     }).then(function(hasDeviceUrl) {
       if (!hasDeviceUrl) {
-        throw new Error('Device URL not enabled');
+        throw new Error('DeviceURL couldn\'t be enabled');
       }
-      return resin.models.device.get(params.uuid).get('uuid').then(performSync);
+      return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync);
     }).then(function() {
       var watch;
       if (!options.watch) {

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -166,14 +166,14 @@ module.exports =
 		resin.models.device.isOnline(params.uuid).tap (isOnline) ->
 			throw new Error('Device is not online') if not isOnline
 		.then ->
-			return resin.models.device.get(params.uuid).get('uuid')
-		.then (fullUUID) ->
-			return resin.models.device.enableDeviceUrl(fullUUID)
-		.then ->
 			return resin.models.device.hasDeviceUrl(params.uuid)
 		.then (hasDeviceUrl) ->
-			throw new Error('DeviceURL couldn\'t be enabled') if not hasDeviceUrl
-			return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync)
+			if hasDeviceUrl
+				return resin.models.device.get(params.uuid).get('uuid').then(performSync)
+			else
+				return resin.models.device.get(params.uuid).get('uuid').then (fullUUID) ->
+					return resin.models.device.enableDeviceUrl(fullUUID).then ->
+						return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync)
 		.then ->
 			return if not options.watch
 

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -166,10 +166,14 @@ module.exports =
 		resin.models.device.isOnline(params.uuid).tap (isOnline) ->
 			throw new Error('Device is not online') if not isOnline
 		.then ->
+			return resin.models.device.get(params.uuid).get('uuid')
+		.then (fullUUID) ->
+			return resin.models.device.enableDeviceUrl(fullUUID)
+		.then ->
 			return resin.models.device.hasDeviceUrl(params.uuid)
 		.then (hasDeviceUrl) ->
-			throw new Error('Device URL not enabled') if not hasDeviceUrl
-			return resin.models.device.get(params.uuid).get('uuid').then(performSync)
+			throw new Error('DeviceURL couldn\'t be enabled') if not hasDeviceUrl
+			return resin.models.device.get(params.uuid).get('uuid').delay(2000).then(performSync)
 		.then ->
 			return if not options.watch
 

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -166,6 +166,9 @@ module.exports =
 		resin.models.device.isOnline(params.uuid).tap (isOnline) ->
 			throw new Error('Device is not online') if not isOnline
 		.then ->
+			return resin.models.device.hasDeviceUrl(params.uuid)
+		.then (hasDeviceUrl) ->
+			throw new Error('Device URL not enabled') if not hasDeviceUrl
 			return resin.models.device.get(params.uuid).get('uuid').then(performSync)
 		.then ->
 			return if not options.watch


### PR DESCRIPTION
The promise chain is sync.coffee is probably not the right way to do things, but needed to have it wait a bit for the deviceURL to establish before making the sync, hence the `.delay(2000)` in the false leg of the condition. I also didn't want that 2 seconds added on each sync, only the first one while it sets up the device URL.
